### PR TITLE
Vagrant for CCPPETMR

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,38 @@
+# Building CCPPETMR_VM via Vagrant
+
+## Installation
+
+- Install VirtualBox
+- Install [Vagrant](https://www.vagrantup.com)
+
+## Vagrant commands
+
+- Start the machine
+
+```
+cd vagrant
+vagrant up
+```
+
+- Pause the machine
+
+```
+vagrant suspend
+```
+
+- Shutdown the machine
+
+```
+vagrant halt
+```
+
+- Remove the machine (to start from scratch)
+
+```
+vagrant destroy
+```
+
+## Documentation
+
+- [https://www.vagrantup.com/docs/](https://www.vagrantup.com/docs/)
+- [https://www.packer.io/intro/](https://www.packer.io/intro/)

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,98 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "box-cutter/ubuntu1604"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    vb.gui = true
+
+  # Customize the amount of memory on the VM:
+    vb.cpus = "2"
+    vb.memory = "4096"
+  end
+
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  
+  config.vm.provision "shell", inline: <<-SHELL
+    SIRFUSERNAME=sirfuser
+    SIRFPASS=virtual
+
+    adduser $SIRFUSERNAME
+    adduser $SIRFUSERNAME sudo
+    { echo $SIRFPASS; echo $SIRFPASS; } | passwd $SIRFUSERNAME 
+
+    apt-get update
+    apt-get install -y wget git xorg xterm gdm menu gksu synaptic gnome-session gnome-panel metacity --no-install-recommends
+ 
+    service gdm start
+
+    # To hide vagrant from login screen:
+    #  1. Log-in as vagrant
+    #  2. In /var/lib/AccountsService/users/vagrant change 'SystemAccount=true'
+
+    # Could add custom logos here: /etc/gdm3/greeter.dconf-defaults 
+
+    cd /opt
+    wget -c https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz
+    cd /usr/local
+    tar xzf /opt/cmake-3.7.2-Linux-x86_64.tar.gz --strip 1
+
+    HOME=/home/sirfuser
+    mkdir $HOME/devel
+    cd $HOME/devel
+
+    export INSTALL_DIR=$HOME/devel/build/install
+    export LD_LIBRARY_PATH=$INSTALL_DIR/lib:$LD_LIBRARY_PATH
+    export PYTHONPATH=$INSTALL_DIR/python 
+    export CMAKE="cmake -DCMAKE_PREFIX_PATH:PATH=$INSTALL_DIR/lib/cmake -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_DIR"
+    export CCMAKE="ccmake -DCMAKE_PREFIX_PATH:PATH=$INSTALL_DIR/lib/cmake -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_DIR"
+
+    git clone https://github.com/CCPPETMR/CCPPETMR_VM.git
+    bash CCPPETMR_VM/scripts/INSTALL_prerequisites_with_apt-get.sh
+    bash CCPPETMR_VM/scripts/UPDATE.sh
+    chown -R sirfuser:users /home/sirfuser/devel
+    
+   SHELL
+end


### PR DESCRIPTION
Build CCPPETMR_VM via Vagrant. Uses Ubuntu 16.04 and GNOME.