### PR TITLE
Creation of VM with SIRF built

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -73,23 +73,36 @@ Vagrant.configure("2") do |config|
     adduser $SIRFUSERNAME sudo
     { echo $SIRFPASS; echo $SIRFPASS; } | passwd $SIRFUSERNAME 
 
-    apt-get update
+   apt-get update
+	# mark grup as hold as it requires user intervention on upgrade!
 	apt-mark hold grub-pc
+	# upgrade the list of packages
 	apt-get upgrade -y
-	apt-get install -y git
-    apt-get install -y wget git xorg xterm gdm menu gksu synaptic gnome-session gnome-panel metacity --no-install-recommends
+	#install upgrades
+	apt-get install -y wget git xorg xterm gdm menu gksu synaptic gnome-session gnome-panel metacity --no-install-recommends
     apt-get install -y at-spi2-core gnome-terminal gnome-control-center nautilus 
     service gdm start
     
-	sudo update-locale LANG=en_US.UTF-8
+	# set the current locale, otherwise the gnome-terminal doesn't start
+	sudo locale-gen en_GB.UTF-8
+	sudo update-locale LANG=en_GB.UTF-8
+	#sudo localectl set-x11-keymap us
+	#sudo localectl list-keymaps
+	#sudo localectl set-locale en_GB.UTF-8
+	# add the input-source to the gnome panel
+	PID=$(pgrep -u $SIRFUSERNAME gnome-session)
+    export DBUS_SESSION_BUS_ADDRESS=$(grep -z DBUS_SESSION_BUS_ADDRESS /proc/$PID/environ|cut -d= -f2-)
+	export DISPLAY=$(grep -z DISPLAY /proc/$PID/environ|cut -d= -f2-)
+    echo "display " $DISPLAY " dbus" $DBUS_SESSION_BUS_ADDRESS
 	sudo gsettings set org.gnome.desktop.input-sources sources "[('xkb','us'),('xkb','uk')]"
-    # To hide vagrant from login screen:
+    
+	# To hide vagrant from login screen:
     #  1. Log-in as vagrant
     #  2. In /var/lib/AccountsService/users/vagrant change 'SystemAccount=true'
 	#cat 'SystemAccount=true' > /var/lib/AccountsService/users/vagrant 
-	cp /var/lib/AccountsService/user/vagrant ~
-	sed -e 's/SystemAccount=.*/SystemAccount=true/' /var/lib/AccountsService/users/vagrant > /tmp/vagrant.user
-    sudo mv /tmp/vagrant.user /var/lib/AccountsService/users/vagrant
+	cp /var/lib/AccountsService/users/vagrant ~
+	sed -e 's/SystemAccount=.*/SystemAccount=true/' /var/lib/AccountsService/users/vagrant > ~/vagrant.user
+    sudo cp -v ~/vagrant.user /var/lib/AccountsService/users/vagrant
 
     # Could add custom logos here: /etc/gdm3/greeter.dconf-defaults 
 
@@ -113,9 +126,9 @@ Vagrant.configure("2") do |config|
 	cd CCPPETMR_VM
 	git pull
 	git checkout v0.9.2
-    #bash $SRC_PATH/CCPPETMR_VM/scripts/INSTALL_prerequisites_with_apt-get.sh
-    #bash $SRC_PATH/CCPPETMR_VM/scripts/UPDATE.sh
-    #chown -R sirfuser:users /home/sirfuser/devel
+    bash $SRC_PATH/CCPPETMR_VM/scripts/INSTALL_prerequisites_with_apt-get.sh
+    bash $SRC_PATH/CCPPETMR_VM/scripts/UPDATE.sh
+    chown -R sirfuser:users /home/sirfuser/devel
     
    SHELL
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -38,6 +38,16 @@ Vagrant.configure("2") do |config|
   # Customize the amount of memory on the VM:
     vb.cpus = "2"
     vb.memory = "4096"
+	
+	vb.customize "pre-boot", [
+       "storageattach", :id,
+       "--storagectl", "IDE Controller",
+        "--port", "1",
+       "--device", "0",
+       "--type", "dvddrive",
+       "--medium", "emptydrive",
+       ]
+	vb.name = "SIRF 0.9.3"
   end
 
   #
@@ -64,13 +74,22 @@ Vagrant.configure("2") do |config|
     { echo $SIRFPASS; echo $SIRFPASS; } | passwd $SIRFUSERNAME 
 
     apt-get update
+	apt-mark hold grub-pc
+	apt-get upgrade -y
+	apt-get install -y git
     apt-get install -y wget git xorg xterm gdm menu gksu synaptic gnome-session gnome-panel metacity --no-install-recommends
     apt-get install -y at-spi2-core gnome-terminal gnome-control-center nautilus 
     service gdm start
-
+    
+	sudo update-locale LANG=en_US.UTF-8
+	sudo gsettings set org.gnome.desktop.input-sources sources "[('xkb','us'),('xkb','uk')]"
     # To hide vagrant from login screen:
     #  1. Log-in as vagrant
     #  2. In /var/lib/AccountsService/users/vagrant change 'SystemAccount=true'
+	#cat 'SystemAccount=true' > /var/lib/AccountsService/users/vagrant 
+	cp /var/lib/AccountsService/user/vagrant ~
+	sed -e 's/SystemAccount=.*/SystemAccount=true/' /var/lib/AccountsService/users/vagrant > /tmp/vagrant.user
+    sudo mv /tmp/vagrant.user /var/lib/AccountsService/users/vagrant
 
     # Could add custom logos here: /etc/gdm3/greeter.dconf-defaults 
 
@@ -91,9 +110,12 @@ Vagrant.configure("2") do |config|
     export CCMAKE="ccmake -DCMAKE_PREFIX_PATH:PATH=$INSTALL_DIR/lib/cmake -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_DIR"
 
     git clone https://github.com/CCPPETMR/CCPPETMR_VM.git
-    bash CCPPETMR_VM/scripts/INSTALL_prerequisites_with_apt-get.sh
-    #bash CCPPETMR_VM/scripts/UPDATE.sh
-    chown -R sirfuser:users /home/sirfuser/devel
+	cd CCPPETMR_VM
+	git pull
+	git checkout v0.9.2
+    #bash $SRC_PATH/CCPPETMR_VM/scripts/INSTALL_prerequisites_with_apt-get.sh
+    #bash $SRC_PATH/CCPPETMR_VM/scripts/UPDATE.sh
+    #chown -R sirfuser:users /home/sirfuser/devel
     
    SHELL
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
        "--type", "dvddrive",
        "--medium", "emptydrive",
        ]
-	vb.name = "SIRF 0.9.3"
+	vb.name = "SIRF_1.0.0"
   end
 
   #
@@ -86,23 +86,19 @@ Vagrant.configure("2") do |config|
 	# set the current locale, otherwise the gnome-terminal doesn't start
 	sudo locale-gen en_GB.UTF-8
 	sudo update-locale LANG=en_GB.UTF-8
+	sudo localectl set-x11-keymap us
+	sudo localectl status
 	#sudo localectl set-x11-keymap us
 	#sudo localectl list-keymaps
 	#sudo localectl set-locale en_GB.UTF-8
-	# add the input-source to the gnome panel
-	PID=$(pgrep -u $SIRFUSERNAME gnome-session)
-    export DBUS_SESSION_BUS_ADDRESS=$(grep -z DBUS_SESSION_BUS_ADDRESS /proc/$PID/environ|cut -d= -f2-)
-	export DISPLAY=$(grep -z DISPLAY /proc/$PID/environ|cut -d= -f2-)
-    echo "display " $DISPLAY " dbus" $DBUS_SESSION_BUS_ADDRESS
-	sudo gsettings set org.gnome.desktop.input-sources sources "[('xkb','us'),('xkb','uk')]"
-    
+	
+	
 	# To hide vagrant from login screen:
     #  1. Log-in as vagrant
     #  2. In /var/lib/AccountsService/users/vagrant change 'SystemAccount=true'
-	#cat 'SystemAccount=true' > /var/lib/AccountsService/users/vagrant 
-	cp /var/lib/AccountsService/users/vagrant ~
-	sed -e 's/SystemAccount=.*/SystemAccount=true/' /var/lib/AccountsService/users/vagrant > ~/vagrant.user
-    sudo cp -v ~/vagrant.user /var/lib/AccountsService/users/vagrant
+	sudo echo '[User]' > vagrant
+	sudo echo 'SystemAccount=true' >> vagrant
+	sudo cp -v vagrant /var/lib/AccountsService/users/vagrant
 
     # Could add custom logos here: /etc/gdm3/greeter.dconf-defaults 
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -46,6 +46,7 @@ Vagrant.configure("2") do |config|
        "--device", "0",
        "--type", "dvddrive",
        "--medium", "emptydrive",
+	   "--clipboard" , "bidirectional"
        ]
 	vb.name = "SIRF_1.0.0"
   end


### PR DESCRIPTION
This Vagrantfile is able to create a VM, and build&install SIRF. 
CTests are run and positive.

Commands needed:

```
vagrant up
vagrant provision
```

Known issues:
 1. https://github.com/CCPPETMR/CCPPETMR_VM/issues/39
