### PR TITLE
handles superbuild tag or hash on update

### DIFF
--- a/scripts/UPDATE.sh
+++ b/scripts/UPDATE.sh
@@ -107,16 +107,15 @@ SuperBuild(){
     cd SIRF-SuperBuild
     git fetch
   fi
-# go to SIRF_TAG
-if [ $1 = 'default' ] 
-then
- # get the latest tag matching v
- SIRF_TAG=`git fetch; git describe --abbrev=0 --tags --match=v*`
-else
- SIRF_TAG=$1
-fi
-echo "***********************************git checkout $SIRF_TAG"
-git checkout $SIRF_TAG
+  # go to SIRF_TAG
+  if [ $1 = 'default' ] 
+  then
+   # get the latest tag matching v
+   SIRF_TAG=`git fetch; git describe --abbrev=0 --tags --match=v*`
+  else
+   SIRF_TAG=$1
+  fi
+  git checkout $SIRF_TAG
   cd ..
   mkdir -p buildVM
   

--- a/scripts/UPDATE.sh
+++ b/scripts/UPDATE.sh
@@ -30,6 +30,14 @@
 set -e
 # give a sensible error message (note: works only in bash)
 trap 'echo An error occurred in $0 at line $LINENO. Current working-dir: $PWD' ERR
+SIRF_TAG='default'
+while getopts :t: option
+ do
+ case "${option}"
+  in
+  t) SIRF_TAG=$OPTARG;;
+ esac
+done
 
 if [ -r ~/.sirfrc ]
 then
@@ -87,8 +95,19 @@ SuperBuild(){
     cd SIRF-SuperBuild
   else
     cd SIRF-SuperBuild
+    git checkout master
     git pull
   fi
+# go to SIRF_TAG
+if [ $1 = 'default' ] 
+then
+ # get the latest tag matching v
+ SIRF_TAG=`git fetch; git describe --abbrev=0 --tags --match=v*`
+else
+ SIRF_TAG=$1
+fi
+echo "***********************************git checkout $SIRF_TAG"
+git checkout $SIRF_TAG
   cd ..
   mkdir -p buildVM
   
@@ -165,7 +184,7 @@ update()
 }
 
 # Launch the SuperBuild to update
-SuperBuild
+SuperBuild $SIRF_TAG
 
 # Get extra python tools
 clone_or_pull ismrmrd-python-tools

--- a/scripts/UPDATE.sh
+++ b/scripts/UPDATE.sh
@@ -36,6 +36,16 @@ while getopts :t: option
  case "${option}"
   in
   t) SIRF_TAG=$OPTARG;;
+  h)
+   echo "Usage: $0 [-t tag]"
+   echo "Use the tag option to checkout a specific version."
+   echo "Otherwise the most recent release will be used."
+   exit 
+   ;;
+  *)
+   echo "Wrong option passed."
+   exit 1
+  ;;
  esac
 done
 
@@ -95,8 +105,7 @@ SuperBuild(){
     cd SIRF-SuperBuild
   else
     cd SIRF-SuperBuild
-    git checkout master
-    git pull
+    git fetch
   fi
 # go to SIRF_TAG
 if [ $1 = 'default' ] 

--- a/scripts/update_VM.sh
+++ b/scripts/update_VM.sh
@@ -1,10 +1,25 @@
 #!/bin/sh
 
 echo "Updating..."
+SIRF_TAG="default"
+while getopts :t: option
+ do
+ case "${option}"
+  in
+  t) SIRF_TAG=$OPTARG;;
+ esac
+done
+
 
 cd ~/devel/CCPPETMR_VM
 git pull
 cd scripts
-./UPDATE.sh
+
+if [ $SIRF_TAG = 'default' ] 
+then
+  ./UPDATE.sh
+else
+ ./UPDATE.sh -t $SIRF_TAG
+fi
 
 echo "All done"

--- a/scripts/update_VM.sh
+++ b/scripts/update_VM.sh
@@ -1,25 +1,11 @@
 #!/bin/sh
 
 echo "Updating..."
-SIRF_TAG="default"
-while getopts :t: option
- do
- case "${option}"
-  in
-  t) SIRF_TAG=$OPTARG;;
- esac
-done
-
 
 cd ~/devel/CCPPETMR_VM
 git pull
 cd scripts
 
-if [ $SIRF_TAG = 'default' ] 
-then
-  ./UPDATE.sh
-else
- ./UPDATE.sh -t $SIRF_TAG
-fi
+./UPDATE.sh $*
 
 echo "All done"


### PR DESCRIPTION
The update_VM.sh and UPDATE.sh accept an option `-t tag` or `-t hash`. If the `-t` option is passed the Superbuild repository is checked out at that particular tag/hash.

closes #26 