### PR TITLE
install CMake via script and use 3.13.1

### DIFF
--- a/scripts/INSTALL_CMake.sh
+++ b/scripts/INSTALL_CMake.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# download/install recent cmake
+# optional first argument is location (e.g. /usr/local (default), $HOME)
+# If using a system location, execute with sudo
+# You need to make sure the resulting location will be in your path
+
+# Authors: Ben Thomas, Kris Thielemans
+# Copyright 2017-2018 University College London
+
+set -e
+if [ $# -eq 0 ]
+then
+    INSTALL_LOC=/usr/local
+else
+    INSTALL_LOC=$1
+fi
+ver=3.13.1
+
+echo "Downloading CMake $ver in /tmp"
+cd /tmp
+# next location could be for older releases (although 3.7.2 was in a 3.7 dir, not 3.7.2)
+# wget -c https://cmake.org/files/${ver}/cmake-${ver}-Linux-x86_64.tar.gz
+wget -c https://github.com/Kitware/CMake/releases/download/v${ver}/cmake-${ver}-Linux-x86_64.tar.gz
+
+echo "Installing CMake $ver in ${INSTALL_LOC}"
+cd ${INSTALL_LOC}
+tar xzf /tmp/cmake-${ver}-Linux-x86_64.tar.gz --strip 1
+rm /tmp/cmake-${ver}-Linux-x86_64.tar.gz

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -140,12 +140,6 @@ Vagrant.configure("2") do |config|
     sudo deluser --remove-home ubuntu
     # Could add custom logos here: /etc/gdm3/greeter.dconf-defaults 
 
-	# download/install cmake
-    cd /opt
-    wget -c https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz
-    cd /usr/local
-    tar xzf /opt/cmake-3.7.2-Linux-x86_64.tar.gz --strip 1
-
     userHOME=/home/$SIRFUSERNAME
     mkdir $userHOME/devel
     cd $userHOME/devel
@@ -153,6 +147,7 @@ Vagrant.configure("2") do |config|
     git clone https://github.com/CCPPETMR/CCPPETMR_VM.git
     cd CCPPETMR_VM
     bash $userHOME/devel/CCPPETMR_VM/scripts/INSTALL_prerequisites_with_apt-get.sh
+    bash $userHOME/devel/CCPPETMR_VM/scripts/INSTALL_CMake.sh /usr/local
     # install jupyter and firefox
     apt-get install -y firefox
     python -m pip install --upgrade pip


### PR DESCRIPTION
- put download of CMake in a separate script such that it's reusable
- use v3.13.1

Fixes #106