### PR TITLE
remove hdfview

### DIFF
--- a/scripts/INSTALL_prerequisites_with_apt-get.sh
+++ b/scripts/INSTALL_prerequisites_with_apt-get.sh
@@ -16,7 +16,7 @@ SUDO=sudo
 echo "Installing Gadgetron pre-requisites..."
 APT_GET_INSTALL="$SUDO apt-get install -y --no-install-recommends"
 ${APT_GET_INSTALL} libhdf5-serial-dev git build-essential libfftw3-dev h5utils hdf5-tools \
-	hdfview liblapack-dev libarmadillo-dev libace-dev libgtest-dev libopenblas-dev \
+	liblapack-dev libarmadillo-dev libace-dev libgtest-dev libopenblas-dev \
 	libatlas-base-dev libatlas-base-dev libxml2-dev libxslt1-dev cython
 
 echo "Installing boost 1.65 or later"


### PR DESCRIPTION
Removes hdfview from apt packages to install as version is too outdated. 
Postpone #129 to 2.1 milestone.